### PR TITLE
add: 確認ダイアログコンポーネントの作成

### DIFF
--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { onMounted, onUnmounted } from 'vue'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
+
+const { confirmDialogState, accept, reject } = useConfirmDialog()
+
+const handleEscapeKey = (event) => {
+  if (event.key === 'Escape' && confirmDialogState.isOpen) {
+    event.preventDefault()
+    reject()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleEscapeKey)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleEscapeKey)
+})
+</script>
+
+<template>
+  <dialog 
+    :open="confirmDialogState.isOpen" 
+    class="modal modal-open"
+    v-if="confirmDialogState.isOpen"
+  >
+    <div class="modal-box">
+      <h3 class="font-bold text-lg mb-4">
+        {{ confirmDialogState.title }}
+      </h3>
+      
+      <p class="py-4">
+        {{ confirmDialogState.message }}
+      </p>
+      
+      <div class="modal-action">
+        <button 
+          @click="reject"
+          class="btn btn-outline"
+        >
+          {{ confirmDialogState.rejectLabel }}
+        </button>
+        
+        <button 
+          @click="accept"
+          class="btn btn-primary"
+        >
+          {{ confirmDialogState.acceptLabel }}
+        </button>
+      </div>
+    </div>
+    
+    <!-- Backdrop -->
+    <div class="modal-backdrop" @click="reject">
+      <button>close</button>
+    </div>
+  </dialog>
+</template>

--- a/resources/js/Components/__tests__/ConfirmDialog.test.js
+++ b/resources/js/Components/__tests__/ConfirmDialog.test.js
@@ -1,0 +1,118 @@
+// ConfirmDialog Component Test
+// 注意: このテストを実行するには、Vitest または Jest のセットアップが必要です
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import ConfirmDialog from '../ConfirmDialog.vue'
+import { useConfirmDialog } from '../../composables/useConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  let wrapper
+  let confirmDialog
+
+  beforeEach(() => {
+    confirmDialog = useConfirmDialog()
+    wrapper = mount(ConfirmDialog)
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    confirmDialog.closeDialog()
+  })
+
+  it('初期状態では表示されていない', () => {
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+    expect(wrapper.find('.modal').exists()).toBe(false)
+  })
+
+  it('confirm関数呼び出し時にダイアログが表示される', async () => {
+    confirmDialog.confirm({
+      title: 'テストタイトル',
+      message: 'テストメッセージ',
+      acceptLabel: 'はい',
+      rejectLabel: 'いいえ'
+    })
+
+    await nextTick()
+
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(true)
+    expect(wrapper.find('.modal-box h3').text()).toBe('テストタイトル')
+    expect(wrapper.find('.modal-box p').text()).toBe('テストメッセージ')
+  })
+
+  it('カスタムボタンラベルが正しく表示される', async () => {
+    confirmDialog.confirm({
+      acceptLabel: 'カスタム受け入れ',
+      rejectLabel: 'カスタム拒否'
+    })
+
+    await nextTick()
+
+    const buttons = wrapper.findAll('.modal-action button')
+    expect(buttons[0].text()).toBe('カスタム拒否')
+    expect(buttons[1].text()).toBe('カスタム受け入れ')
+  })
+
+  it('受け入れボタンクリック時にPromiseがresolveされる', async () => {
+    const promise = confirmDialog.confirm({ message: 'テスト' })
+    
+    await nextTick()
+    
+    const acceptButton = wrapper.find('.btn-primary')
+    await acceptButton.trigger('click')
+
+    await expect(promise).resolves.toBe(true)
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+  })
+
+  it('拒否ボタンクリック時にPromiseがrejectされる', async () => {
+    const promise = confirmDialog.confirm({ message: 'テスト' })
+    
+    await nextTick()
+    
+    const rejectButton = wrapper.find('.btn-outline')
+    await rejectButton.trigger('click')
+
+    await expect(promise).rejects.toBe(false)
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+  })
+
+  it('背景クリック時にダイアログが閉じられる', async () => {
+    const promise = confirmDialog.confirm({ message: 'テスト' })
+    
+    await nextTick()
+    
+    const backdrop = wrapper.find('.modal-backdrop')
+    await backdrop.trigger('click')
+
+    await expect(promise).rejects.toBe(false)
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+  })
+
+  it('ESCキー押下時にダイアログが閉じられる', async () => {
+    const promise = confirmDialog.confirm({ message: 'テスト' })
+    
+    await nextTick()
+
+    // ESCキーイベントをシミュレート
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    document.dispatchEvent(event)
+
+    await expect(promise).rejects.toBe(false)
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+  })
+
+  it('デフォルトのラベルとタイトルが使用される', async () => {
+    confirmDialog.confirm()
+
+    await nextTick()
+
+    expect(wrapper.find('.modal-box h3').text()).toBe('確認')
+    expect(wrapper.find('.modal-box p').text()).toBe('実行してもよろしいですか？')
+    
+    const buttons = wrapper.findAll('.modal-action button')
+    expect(buttons[0].text()).toBe('拒否する')
+    expect(buttons[1].text()).toBe('受け入れる')
+  })
+})

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -194,5 +194,8 @@ const showingNavigationDropdown = ref(false);
                 <slot />
             </main>
         </div>
+        
+        <!-- Global Confirmation Dialog -->
+        <ConfirmDialog />
     </div>
 </template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,6 +1,35 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head } from '@inertiajs/vue3';
+import { useConfirmDialog } from '@/composables/useConfirmDialog';
+
+const { confirm } = useConfirmDialog();
+
+const handleDeleteAction = async () => {
+    try {
+        const result = await confirm({
+            title: '削除確認',
+            message: 'この操作を実行すると、データが削除されます。本当に実行しますか？',
+            acceptLabel: '削除する',
+            rejectLabel: 'キャンセル'
+        });
+        
+        if (result) {
+            alert('削除が実行されました');
+        }
+    } catch (rejected) {
+        alert('削除がキャンセルされました');
+    }
+};
+
+const handleSimpleConfirm = async () => {
+    try {
+        await confirm();
+        alert('受け入れられました');
+    } catch (rejected) {
+        alert('拒否されました');
+    }
+};
 </script>
 
 <template>
@@ -21,7 +50,26 @@ import { Head } from '@inertiajs/vue3';
                     class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800"
                 >
                     <div class="p-6 text-gray-900 dark:text-gray-100">
-                        You're logged in!
+                        <h3 class="text-lg font-semibold mb-4">You're logged in!</h3>
+                        
+                        <div class="space-y-4">
+                            <h4 class="text-md font-medium">確認ダイアログのテスト</h4>
+                            <div class="space-x-4">
+                                <button
+                                    @click="handleSimpleConfirm"
+                                    class="btn btn-primary"
+                                >
+                                    デフォルト確認ダイアログ
+                                </button>
+                                
+                                <button
+                                    @click="handleDeleteAction"
+                                    class="btn btn-error"
+                                >
+                                    削除確認ダイアログ
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,6 +5,7 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createApp, h } from 'vue';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
+import ConfirmDialog from './Components/ConfirmDialog.vue';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -19,6 +20,7 @@ createInertiaApp({
         return createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue)
+            .component('ConfirmDialog', ConfirmDialog)
             .mount(el);
     },
     progress: {

--- a/resources/js/composables/__tests__/useConfirmDialog.test.js
+++ b/resources/js/composables/__tests__/useConfirmDialog.test.js
@@ -1,0 +1,98 @@
+// useConfirmDialog Composable Test
+// 注意: このテストを実行するには、Vitest または Jest のセットアップが必要です
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useConfirmDialog } from '../useConfirmDialog'
+
+describe('useConfirmDialog', () => {
+  let confirmDialog
+
+  beforeEach(() => {
+    confirmDialog = useConfirmDialog()
+    confirmDialog.closeDialog() // 状態をリセット
+  })
+
+  it('初期状態が正しく設定される', () => {
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+    expect(confirmDialog.confirmDialogState.title).toBe('')
+    expect(confirmDialog.confirmDialogState.message).toBe('')
+    expect(confirmDialog.confirmDialogState.acceptLabel).toBe('受け入れる')
+    expect(confirmDialog.confirmDialogState.rejectLabel).toBe('拒否する')
+    expect(confirmDialog.confirmDialogState.resolve).toBe(null)
+    expect(confirmDialog.confirmDialogState.reject).toBe(null)
+  })
+
+  it('confirm関数がデフォルト値で正しく動作する', () => {
+    const promise = confirmDialog.confirm()
+
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(true)
+    expect(confirmDialog.confirmDialogState.title).toBe('確認')
+    expect(confirmDialog.confirmDialogState.message).toBe('実行してもよろしいですか？')
+    expect(confirmDialog.confirmDialogState.acceptLabel).toBe('受け入れる')
+    expect(confirmDialog.confirmDialogState.rejectLabel).toBe('拒否する')
+    expect(promise).toBeInstanceOf(Promise)
+  })
+
+  it('confirm関数がカスタムオプションで正しく動作する', () => {
+    const options = {
+      title: 'カスタムタイトル',
+      message: 'カスタムメッセージ',
+      acceptLabel: 'はい',
+      rejectLabel: 'いいえ'
+    }
+
+    confirmDialog.confirm(options)
+
+    expect(confirmDialog.confirmDialogState.title).toBe('カスタムタイトル')
+    expect(confirmDialog.confirmDialogState.message).toBe('カスタムメッセージ')
+    expect(confirmDialog.confirmDialogState.acceptLabel).toBe('はい')
+    expect(confirmDialog.confirmDialogState.rejectLabel).toBe('いいえ')
+  })
+
+  it('accept関数が正しく動作する', async () => {
+    const promise = confirmDialog.confirm()
+    
+    confirmDialog.accept()
+
+    await expect(promise).resolves.toBe(true)
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+  })
+
+  it('reject関数が正しく動作する', async () => {
+    const promise = confirmDialog.confirm()
+    
+    confirmDialog.reject()
+
+    await expect(promise).rejects.toBe(false)
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+  })
+
+  it('closeDialog関数が状態を正しくリセットする', () => {
+    confirmDialog.confirm({
+      title: 'テスト',
+      message: 'テスト',
+      acceptLabel: 'テスト',
+      rejectLabel: 'テスト'
+    })
+
+    confirmDialog.closeDialog()
+
+    expect(confirmDialog.confirmDialogState.isOpen).toBe(false)
+    expect(confirmDialog.confirmDialogState.title).toBe('')
+    expect(confirmDialog.confirmDialogState.message).toBe('')
+    expect(confirmDialog.confirmDialogState.acceptLabel).toBe('受け入れる')
+    expect(confirmDialog.confirmDialogState.rejectLabel).toBe('拒否する')
+    expect(confirmDialog.confirmDialogState.resolve).toBe(null)
+    expect(confirmDialog.confirmDialogState.reject).toBe(null)
+  })
+
+  it('複数のconfirmDialog インスタンスが同じ状態を共有する', () => {
+    const confirmDialog1 = useConfirmDialog()
+    const confirmDialog2 = useConfirmDialog()
+
+    confirmDialog1.confirm({ title: 'テスト1' })
+
+    expect(confirmDialog2.confirmDialogState.title).toBe('テスト1')
+    expect(confirmDialog2.confirmDialogState.isOpen).toBe(true)
+  })
+})

--- a/resources/js/composables/useConfirmDialog.js
+++ b/resources/js/composables/useConfirmDialog.js
@@ -1,0 +1,64 @@
+import { ref, reactive } from 'vue'
+
+const confirmDialogState = reactive({
+  isOpen: false,
+  title: '',
+  message: '',
+  acceptLabel: '受け入れる',
+  rejectLabel: '拒否する',
+  resolve: null,
+  reject: null
+})
+
+export function useConfirmDialog() {
+  const confirm = (options = {}) => {
+    const {
+      title = '確認',
+      message = '実行してもよろしいですか？',
+      acceptLabel = '受け入れる',
+      rejectLabel = '拒否する'
+    } = options
+
+    return new Promise((resolve, reject) => {
+      confirmDialogState.isOpen = true
+      confirmDialogState.title = title
+      confirmDialogState.message = message
+      confirmDialogState.acceptLabel = acceptLabel
+      confirmDialogState.rejectLabel = rejectLabel
+      confirmDialogState.resolve = resolve
+      confirmDialogState.reject = reject
+    })
+  }
+
+  const accept = () => {
+    if (confirmDialogState.resolve) {
+      confirmDialogState.resolve(true)
+    }
+    closeDialog()
+  }
+
+  const reject = () => {
+    if (confirmDialogState.reject) {
+      confirmDialogState.reject(false)
+    }
+    closeDialog()
+  }
+
+  const closeDialog = () => {
+    confirmDialogState.isOpen = false
+    confirmDialogState.title = ''
+    confirmDialogState.message = ''
+    confirmDialogState.acceptLabel = '受け入れる'
+    confirmDialogState.rejectLabel = '拒否する'
+    confirmDialogState.resolve = null
+    confirmDialogState.reject = null
+  }
+
+  return {
+    confirmDialogState,
+    confirm,
+    accept,
+    reject,
+    closeDialog
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
+import { resolve } from 'path';
 
 export default defineConfig({
     plugins: [
@@ -17,4 +18,9 @@ export default defineConfig({
             },
         }),
     ],
+    resolve: {
+        alias: {
+            '@': resolve(__dirname, 'resources/js'),
+        },
+    },
 });


### PR DESCRIPTION
## 概要
DaisyUIベースの確認ダイアログコンポーネントとコンポーザブルを実装しました。

## 主な変更
- ConfirmDialogコンポーネントの作成
- useConfirmDialogコンポーザブルの作成
- カスタマイズ可能なボタンラベル対応
- ESCキーで拒否動作実装
- Promise-based APIで非同期処理対応
- Vueテストファイル作成

Closed #2

Generated with [Claude Code](https://claude.ai/code)