### PR TITLE
add: 確認ダイアログコンポーネントの作成

### DIFF
--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -46,16 +46,13 @@ const closeDialog = () => {
 
 const handleKeydown = (event) => {
   if (event.key === 'Escape') {
-    event.preventDefault()
-    event.stopPropagation()
+    handleReject()
   }
 }
 
 watch(() => props.isOpen, (newValue) => {
   if (newValue && dialogRef.value) {
     dialogRef.value.showModal()
-    // ダイアログにフォーカスを設定
-    dialogRef.value.focus()
   } else if (!newValue && dialogRef.value) {
     dialogRef.value.close()
   }
@@ -74,6 +71,7 @@ watch(() => props.isOpen, (newValue) => {
       <div class="modal-action">
         <button 
           class="btn btn-error"
+          autofocus
           @click="handleReject"
         >
           {{ rejectLabel }}

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -54,6 +54,8 @@ const handleKeydown = (event) => {
 watch(() => props.isOpen, (newValue) => {
   if (newValue && dialogRef.value) {
     dialogRef.value.showModal()
+    // ダイアログにフォーカスを設定
+    dialogRef.value.focus()
   } else if (!newValue && dialogRef.value) {
     dialogRef.value.close()
   }

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { useTemplateRef, watch } from 'vue'
+
+const props = defineProps({
+  isOpen: {
+    type: Boolean,
+    default: false
+  },
+  title: {
+    type: String,
+    default: '確認'
+  },
+  message: {
+    type: String,
+    required: true
+  },
+  acceptLabel: {
+    type: String,
+    default: '受け入れる'
+  },
+  rejectLabel: {
+    type: String,
+    default: '拒否する'
+  }
+})
+
+const emit = defineEmits(['accept', 'reject'])
+
+const dialogRef = useTemplateRef('dialog')
+
+const handleAccept = () => {
+  emit('accept')
+  closeDialog()
+}
+
+const handleReject = () => {
+  emit('reject')
+  closeDialog()
+}
+
+const closeDialog = () => {
+  if (dialogRef.value) {
+    dialogRef.value.close()
+  }
+}
+
+const handleKeydown = (event) => {
+  if (event.key === 'Escape') {
+    handleReject()
+  }
+}
+
+watch(() => props.isOpen, (newValue) => {
+  if (newValue && dialogRef.value) {
+    dialogRef.value.showModal()
+  } else if (!newValue && dialogRef.value) {
+    dialogRef.value.close()
+  }
+}, { immediate: true })
+</script>
+
+<template>
+  <dialog
+    ref="dialog"
+    class="modal"
+    @keydown="handleKeydown"
+  >
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">{{ title }}</h3>
+      <p class="py-4">{{ message }}</p>
+      <div class="modal-action">
+        <button 
+          class="btn btn-error"
+          @click="handleReject"
+        >
+          {{ rejectLabel }}
+        </button>
+        <button 
+          class="btn btn-primary"
+          @click="handleAccept"
+        >
+          {{ acceptLabel }}
+        </button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button @click="handleReject">close</button>
+    </form>
+  </dialog>
+</template>

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useTemplateRef, watch } from 'vue'
+import { useTemplateRef, watch, nextTick } from 'vue'
 
 const props = defineProps({
   isOpen: {
@@ -27,6 +27,7 @@ const props = defineProps({
 const emit = defineEmits(['accept', 'reject'])
 
 const dialogRef = useTemplateRef('dialog')
+const rejectButtonRef = useTemplateRef('rejectButton')
 
 const handleAccept = () => {
   emit('accept')
@@ -46,13 +47,19 @@ const closeDialog = () => {
 
 const handleKeydown = (event) => {
   if (event.key === 'Escape') {
-    handleReject()
+    event.preventDefault()
+    event.stopPropagation()
   }
 }
 
 watch(() => props.isOpen, (newValue) => {
   if (newValue && dialogRef.value) {
     dialogRef.value.showModal()
+    nextTick(() => {
+      if (rejectButtonRef.value) {
+        rejectButtonRef.value.focus()
+      }
+    })
   } else if (!newValue && dialogRef.value) {
     dialogRef.value.close()
   }
@@ -70,8 +77,8 @@ watch(() => props.isOpen, (newValue) => {
       <p class="py-4">{{ message }}</p>
       <div class="modal-action">
         <button 
+          ref="rejectButton"
           class="btn btn-error"
-          autofocus
           @click="handleReject"
         >
           {{ rejectLabel }}

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useTemplateRef, watch, nextTick } from 'vue'
+import { useTemplateRef, watch } from 'vue'
 
 const props = defineProps({
   isOpen: {
@@ -56,11 +56,11 @@ const handleKeydown = (event) => {
 watch(() => props.isOpen, (newValue) => {
   if (newValue && dialogRef.value) {
     dialogRef.value.showModal()
-    nextTick(() => {
+    setTimeout(() => {
       if (rejectButtonRef.value) {
         rejectButtonRef.value.focus()
       }
-    })
+    }, 100)
   } else if (!newValue && dialogRef.value) {
     dialogRef.value.close()
   }

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -46,7 +46,8 @@ const closeDialog = () => {
 
 const handleKeydown = (event) => {
   if (event.key === 'Escape') {
-    handleReject()
+    event.preventDefault()
+    event.stopPropagation()
   }
 }
 

--- a/resources/js/Components/ConfirmDialog.vue
+++ b/resources/js/Components/ConfirmDialog.vue
@@ -49,6 +49,7 @@ const handleKeydown = (event) => {
   if (event.key === 'Escape') {
     event.preventDefault()
     event.stopPropagation()
+    handleReject()
   }
 }
 

--- a/resources/js/Layouts/RootLayout.vue
+++ b/resources/js/Layouts/RootLayout.vue
@@ -1,5 +1,8 @@
 <script setup>
-// 今後、ナビゲーションバーなどの共通部品が追加される予定
+import ConfirmDialog from '@/Components/ConfirmDialog.vue'
+import { useConfirmDialog } from '@/composables/useConfirmDialog.js'
+
+const { isDialogOpen, dialogConfig, handleAccept, handleReject } = useConfirmDialog()
 </script>
 
 <template>
@@ -10,5 +13,16 @@
         <main class="container mx-auto">
             <slot />
         </main>
+        
+        <!-- 確認ダイアログ -->
+        <ConfirmDialog
+            :is-open="isDialogOpen"
+            :title="dialogConfig.title"
+            :message="dialogConfig.message"
+            :accept-label="dialogConfig.acceptLabel"
+            :reject-label="dialogConfig.rejectLabel"
+            @accept="handleAccept"
+            @reject="handleReject"
+        />
     </div>
 </template>

--- a/resources/js/Pages/Components.vue
+++ b/resources/js/Pages/Components.vue
@@ -1,6 +1,24 @@
 <script setup>
 import RootLayout from '@/Layouts/RootLayout.vue';
 import { Head } from '@inertiajs/vue3';
+import { useConfirmDialog } from '@/composables/useConfirmDialog.js';
+
+const { showConfirmDialog } = useConfirmDialog()
+
+const handleTestDialog = async () => {
+  const result = await showConfirmDialog({
+    title: 'テスト確認',
+    message: 'このダイアログはテスト用です。操作を続行しますか？',
+    acceptLabel: '続行する',
+    rejectLabel: 'キャンセル'
+  })
+  
+  if (result) {
+    alert('受け入れられました')
+  } else {
+    alert('拒否されました')
+  }
+}
 </script>
 
 <template>
@@ -20,6 +38,19 @@ import { Head } from '@inertiajs/vue3';
                                     このページはRootLayoutコンポーネントを使用しています。
                                     全ページ共通の最上位レイアウトとして機能し、メイン部分をスロットで受け入れます。
                                 </p>
+                            </section>
+                            
+                            <section>
+                                <h2 class="text-lg font-semibold mb-4">ConfirmDialog</h2>
+                                <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                    確認ダイアログコンポーネントのテストです。
+                                </p>
+                                <button 
+                                    class="btn btn-primary"
+                                    @click="handleTestDialog"
+                                >
+                                    確認ダイアログをテスト
+                                </button>
                             </section>
                         </div>
                     </div>

--- a/resources/js/composables/useConfirmDialog.js
+++ b/resources/js/composables/useConfirmDialog.js
@@ -1,0 +1,51 @@
+import { ref } from 'vue'
+
+export function useConfirmDialog() {
+  const isDialogOpen = ref(false)
+  const dialogConfig = ref({
+    title: '確認',
+    message: '',
+    acceptLabel: '受け入れる',
+    rejectLabel: '拒否する'
+  })
+  
+  let resolvePromise = null
+
+  const showConfirmDialog = (options = {}) => {
+    return new Promise((resolve) => {
+      dialogConfig.value = {
+        title: options.title || '確認',
+        message: options.message || '',
+        acceptLabel: options.acceptLabel || '受け入れる',
+        rejectLabel: options.rejectLabel || '拒否する'
+      }
+      
+      resolvePromise = resolve
+      isDialogOpen.value = true
+    })
+  }
+
+  const handleAccept = () => {
+    isDialogOpen.value = false
+    if (resolvePromise) {
+      resolvePromise(true)
+      resolvePromise = null
+    }
+  }
+
+  const handleReject = () => {
+    isDialogOpen.value = false
+    if (resolvePromise) {
+      resolvePromise(false)
+      resolvePromise = null
+    }
+  }
+
+  return {
+    isDialogOpen,
+    dialogConfig,
+    showConfirmDialog,
+    handleAccept,
+    handleReject
+  }
+}

--- a/resources/js/composables/useConfirmDialog.js
+++ b/resources/js/composables/useConfirmDialog.js
@@ -1,16 +1,17 @@
 import { ref } from 'vue'
 
-export function useConfirmDialog() {
-  const isDialogOpen = ref(false)
-  const dialogConfig = ref({
-    title: '確認',
-    message: '',
-    acceptLabel: '受け入れる',
-    rejectLabel: '拒否する'
-  })
-  
-  let resolvePromise = null
+// グローバル状態
+const isDialogOpen = ref(false)
+const dialogConfig = ref({
+  title: '確認',
+  message: '',
+  acceptLabel: '受け入れる',
+  rejectLabel: '拒否する'
+})
 
+let resolvePromise = null
+
+export function useConfirmDialog() {
   const showConfirmDialog = (options = {}) => {
     return new Promise((resolve) => {
       dialogConfig.value = {

--- a/resources/js/composables/useConfirmDialog.test.js
+++ b/resources/js/composables/useConfirmDialog.test.js
@@ -8,6 +8,14 @@ describe('useConfirmDialog', () => {
 
   beforeEach(() => {
     composable = useConfirmDialog()
+    // グローバル状態をリセット
+    composable.isDialogOpen.value = false
+    composable.dialogConfig.value = {
+      title: '確認',
+      message: '',
+      acceptLabel: '受け入れる',
+      rejectLabel: '拒否する'
+    }
   })
 
   it('初期状態でダイアログが閉じている', () => {
@@ -82,6 +90,18 @@ describe('useConfirmDialog', () => {
 })
 
 describe('useConfirmDialog DOM integration', () => {
+  beforeEach(() => {
+    // グローバル状態をリセット
+    const composable = useConfirmDialog()
+    composable.isDialogOpen.value = false
+    composable.dialogConfig.value = {
+      title: '確認',
+      message: '',
+      acceptLabel: '受け入れる',
+      rejectLabel: '拒否する'
+    }
+  })
+
   const TestComponent = {
     template: `
       <div>

--- a/resources/js/composables/useConfirmDialog.test.js
+++ b/resources/js/composables/useConfirmDialog.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { useConfirmDialog } from './useConfirmDialog.js'
+import { nextTick } from 'vue'
+
+describe('useConfirmDialog', () => {
+  let composable
+
+  beforeEach(() => {
+    composable = useConfirmDialog()
+  })
+
+  it('初期状態でダイアログが閉じている', () => {
+    expect(composable.isDialogOpen.value).toBe(false)
+  })
+
+  it('showConfirmDialogでダイアログが開く', async () => {
+    const promise = composable.showConfirmDialog({
+      message: 'テストメッセージ'
+    })
+
+    await nextTick()
+    expect(composable.isDialogOpen.value).toBe(true)
+    expect(composable.dialogConfig.value.message).toBe('テストメッセージ')
+
+    composable.handleAccept()
+    const result = await promise
+    expect(result).toBe(true)
+  })
+
+  it('カスタムオプションが正しく設定される', async () => {
+    composable.showConfirmDialog({
+      title: 'カスタムタイトル',
+      message: 'カスタムメッセージ',
+      acceptLabel: 'はい',
+      rejectLabel: 'いいえ'
+    })
+
+    await nextTick()
+    
+    expect(composable.dialogConfig.value.title).toBe('カスタムタイトル')
+    expect(composable.dialogConfig.value.message).toBe('カスタムメッセージ')
+    expect(composable.dialogConfig.value.acceptLabel).toBe('はい')
+    expect(composable.dialogConfig.value.rejectLabel).toBe('いいえ')
+  })
+
+  it('handleAcceptでtrueが返される', async () => {
+    const promise = composable.showConfirmDialog({
+      message: 'テスト'
+    })
+
+    composable.handleAccept()
+    const result = await promise
+
+    expect(result).toBe(true)
+    expect(composable.isDialogOpen.value).toBe(false)
+  })
+
+  it('handleRejectでfalseが返される', async () => {
+    const promise = composable.showConfirmDialog({
+      message: 'テスト'
+    })
+
+    composable.handleReject()
+    const result = await promise
+
+    expect(result).toBe(false)
+    expect(composable.isDialogOpen.value).toBe(false)
+  })
+
+  it('デフォルト値が正しく設定される', async () => {
+    composable.showConfirmDialog({
+      message: 'テスト'
+    })
+
+    await nextTick()
+    
+    expect(composable.dialogConfig.value.title).toBe('確認')
+    expect(composable.dialogConfig.value.acceptLabel).toBe('受け入れる')
+    expect(composable.dialogConfig.value.rejectLabel).toBe('拒否する')
+  })
+})
+
+describe('useConfirmDialog DOM integration', () => {
+  const TestComponent = {
+    template: `
+      <div>
+        <button @click="showDialog" data-testid="trigger">テストボタン</button>
+        <div v-if="isDialogOpen" data-testid="dialog" role="dialog">
+          <p data-testid="dialog-message">{{ dialogConfig.message }}</p>
+          <button @click="handleAccept" data-testid="accept">{{ dialogConfig.acceptLabel }}</button>
+          <button @click="handleReject" data-testid="reject">{{ dialogConfig.rejectLabel }}</button>
+        </div>
+      </div>
+    `,
+    setup() {
+      const { isDialogOpen, dialogConfig, showConfirmDialog, handleAccept, handleReject } = useConfirmDialog()
+      
+      const showDialog = () => {
+        showConfirmDialog({
+          message: 'DOM テストメッセージ',
+          acceptLabel: 'OK',
+          rejectLabel: 'Cancel'
+        })
+      }
+      
+      return {
+        isDialogOpen,
+        dialogConfig,
+        showDialog,
+        handleAccept,
+        handleReject
+      }
+    }
+  }
+
+  it('ダイアログが正しくDOMに表示される', async () => {
+    const wrapper = mount(TestComponent)
+    
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(false)
+    
+    await wrapper.find('[data-testid="trigger"]').trigger('click')
+    await nextTick()
+    
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="dialog-message"]').text()).toBe('DOM テストメッセージ')
+    expect(wrapper.find('[data-testid="accept"]').text()).toBe('OK')
+    expect(wrapper.find('[data-testid="reject"]').text()).toBe('Cancel')
+  })
+
+  it('Acceptボタンクリックでダイアログが閉じる', async () => {
+    const wrapper = mount(TestComponent)
+    
+    await wrapper.find('[data-testid="trigger"]').trigger('click')
+    await nextTick()
+    
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(true)
+    
+    await wrapper.find('[data-testid="accept"]').trigger('click')
+    await nextTick()
+    
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(false)
+  })
+
+  it('Rejectボタンクリックでダイアログが閉じる', async () => {
+    const wrapper = mount(TestComponent)
+    
+    await wrapper.find('[data-testid="trigger"]').trigger('click')
+    await nextTick()
+    
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(true)
+    
+    await wrapper.find('[data-testid="reject"]').trigger('click')
+    await nextTick()
+    
+    expect(wrapper.find('[data-testid="dialog"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
Issue #14 の対応: 確認ダイアログコンポーネントを作成しました。

## 実装内容
- DaisyUIを使用したConfirmDialog.vueコンポーネント
- useConfirmDialogコンポーザブルでの制御ロジック
- useTemplateRef()を使用したdialog要素への参照
- ESCキー対応
- RootLayoutへの統合
- テストボタンの追加
- 包括的なテストの実装

Generated with [Claude Code](https://claude.ai/code)