### PR TITLE
add: 一般ユーザー用マイページを作成

### DIFF
--- a/app/Http/Controllers/MyPageController.php
+++ b/app/Http/Controllers/MyPageController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * マイページコントローラー
+ * 
+ * ユーザーの個人情報や活動履歴を表示する
+ */
+class MyPageController extends Controller
+{
+    /**
+     * マイページを表示
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function index(Request $request): Response
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        
+        return Inertia::render('MyPage/Index', [
+            'user' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'role' => $user->role,
+                'status' => $user->status,
+                'created_at' => $user->created_at->format('Y年m月d日'),
+                'email_verified_at' => $user->email_verified_at?->format('Y年m月d日 H:i'),
+            ],
+        ]);
+    }
+}

--- a/resources/js/Components/NavigationBar.test.js
+++ b/resources/js/Components/NavigationBar.test.js
@@ -1,26 +1,56 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import NavigationBar from './NavigationBar.vue';
 
 // routeヘルパーをモック
 const mockRoute = vi.fn((name) => `/${name.replace('.', '/')}`)
 
-// Linkコンポーネントをモック
-const MockLink = {
-  name: 'Link',
-  props: ['href', 'method', 'as'],
-  template: '<a :href="href"><slot /></a>'
+// usePageのモックデータ
+let mockPageData = {
+    props: {
+        auth: {
+            user: {
+                id: 1,
+                name: 'Test User',
+                email: 'test@example.com',
+                role: 'user'
+            }
+        }
+    }
 }
 
+// Inertia.jsのモック
+vi.mock('@inertiajs/vue3', () => ({
+    Link: {
+        name: 'Link',
+        props: ['href', 'method', 'as'],
+        template: '<a :href="href"><slot /></a>'
+    },
+    usePage: vi.fn(() => mockPageData)
+}))
+
 describe('NavigationBar', () => {
+    beforeEach(() => {
+        // 各テストの前にデフォルトのユーザーデータをリセット
+        mockPageData = {
+            props: {
+                auth: {
+                    user: {
+                        id: 1,
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        role: 'user'
+                    }
+                }
+            }
+        }
+    })
+
     it('デフォルトのブランドロゴが表示される', () => {
         const wrapper = mount(NavigationBar, {
             global: {
                 mocks: {
                     route: mockRoute
-                },
-                components: {
-                    Link: MockLink
                 }
             }
         });
@@ -37,9 +67,6 @@ describe('NavigationBar', () => {
             global: {
                 mocks: {
                     route: mockRoute
-                },
-                components: {
-                    Link: MockLink
                 }
             }
         });
@@ -52,9 +79,6 @@ describe('NavigationBar', () => {
             global: {
                 mocks: {
                     route: mockRoute
-                },
-                components: {
-                    Link: MockLink
                 }
             }
         });
@@ -68,9 +92,6 @@ describe('NavigationBar', () => {
             global: {
                 mocks: {
                     route: mockRoute
-                },
-                components: {
-                    Link: MockLink
                 }
             }
         });
@@ -79,14 +100,14 @@ describe('NavigationBar', () => {
         expect(menuItems.exists()).toBe(true);
     });
 
-    it('デフォルトのメニュー項目が表示される', () => {
+    it('管理者用のメニュー項目が表示される', () => {
+        // 管理者用のデータを設定
+        mockPageData.props.auth.user.role = 'admin';
+
         const wrapper = mount(NavigationBar, {
             global: {
                 mocks: {
                     route: mockRoute
-                },
-                components: {
-                    Link: MockLink
                 }
             }
         });
@@ -95,17 +116,48 @@ describe('NavigationBar', () => {
         expect(menuText).toContain('ダッシュボード');
         expect(menuText).toContain('ユーザー管理');
         expect(menuText).toContain('システム設定');
+        expect(menuText).toContain('ユーザーレポート');
+        expect(menuText).toContain('システムレポート');
     });
 
+    it('一般ユーザー用のメニュー項目が表示される', () => {
+        // 一般ユーザー用のデータを設定
+        mockPageData.props.auth.user.role = 'user';
+
+        const wrapper = mount(NavigationBar, {
+            global: {
+                mocks: {
+                    route: mockRoute
+                }
+            }
+        });
+        
+        const menuText = wrapper.text();
+        expect(menuText).toContain('ダッシュボード');
+        expect(menuText).toContain('マイページ');
+        expect(menuText).not.toContain('ユーザー管理');
+        expect(menuText).not.toContain('システム設定');
+    });
+
+    it('共通メニュー項目が表示される', () => {
+        const wrapper = mount(NavigationBar, {
+            global: {
+                mocks: {
+                    route: mockRoute
+                }
+            }
+        });
+        
+        const menuText = wrapper.text();
+        expect(menuText).toContain('プロフィール');
+        expect(menuText).toContain('ログアウト');
+    });
 
     it('正しいDaisyUIクラスが適用されている', () => {
         const wrapper = mount(NavigationBar, {
             global: {
                 mocks: {
                     route: mockRoute
-                },
-                components: {
-                    Link: MockLink
                 }
             }
         });

--- a/resources/js/Components/NavigationBar.vue
+++ b/resources/js/Components/NavigationBar.vue
@@ -44,7 +44,7 @@
                     <!-- 一般ユーザーメニュー -->
                     <template v-else>
                         <li><Link :href="route('dashboard')">🏠 ダッシュボード</Link></li>
-                        <li><Link :href="route('mypage.index')">📋 マイページ</Link></li>
+                        <li><Link :href="route('mypage')">📋 マイページ</Link></li>
                         <li><hr /></li>
                     </template>
                     

--- a/resources/js/Components/NavigationBar.vue
+++ b/resources/js/Components/NavigationBar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="navbar bg-base-100 shadow-lg">
         <div class="navbar-start">
-            <Link :href="route('admin.dashboard')" class="btn btn-ghost text-xl">{{ brandLogo }}</Link>
+            <Link :href="homeRoute" class="btn btn-ghost text-xl">{{ brandLogo }}</Link>
         </div>
         <div class="navbar-end">
             <div class="dropdown dropdown-end">
@@ -30,13 +30,25 @@
                     class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow"
                     data-testid="menu-items"
                 >
-                    <li><Link :href="route('admin.dashboard')">📊 ダッシュボード</Link></li>
-                    <li><Link :href="route('admin.users.index')">👥 ユーザー管理</Link></li>
-                    <li><Link :href="route('admin.settings.index')">⚙️ システム設定</Link></li>
-                    <li><hr /></li>
-                    <li><Link :href="route('admin.reports.users')">📈 ユーザーレポート</Link></li>
-                    <li><Link :href="route('admin.reports.system')">🖥️ システムレポート</Link></li>
-                    <li><hr /></li>
+                    <!-- 管理者メニュー -->
+                    <template v-if="isAdmin">
+                        <li><Link :href="route('admin.dashboard')">📊 ダッシュボード</Link></li>
+                        <li><Link :href="route('admin.users.index')">👥 ユーザー管理</Link></li>
+                        <li><Link :href="route('admin.settings.index')">⚙️ システム設定</Link></li>
+                        <li><hr /></li>
+                        <li><Link :href="route('admin.reports.users')">📈 ユーザーレポート</Link></li>
+                        <li><Link :href="route('admin.reports.system')">🖥️ システムレポート</Link></li>
+                        <li><hr /></li>
+                    </template>
+                    
+                    <!-- 一般ユーザーメニュー -->
+                    <template v-else>
+                        <li><Link :href="route('dashboard')">🏠 ダッシュボード</Link></li>
+                        <li><Link :href="route('mypage.index')">📋 マイページ</Link></li>
+                        <li><hr /></li>
+                    </template>
+                    
+                    <!-- 共通メニュー -->
                     <li>
                         <Link :href="route('profile.edit')" class="text-info">👤 プロフィール</Link>
                     </li>
@@ -52,7 +64,9 @@
 </template>
 
 <script setup lang="ts">
-import { Link } from '@inertiajs/vue3'
+import { Link, usePage } from '@inertiajs/vue3'
+import { computed } from 'vue'
+import type { PageProps } from '@/types/inertia'
 
 interface Props {
     brandLogo?: string;
@@ -60,5 +74,22 @@ interface Props {
 
 withDefaults(defineProps<Props>(), {
     brandLogo: 'SimpleApp'
+});
+
+// ページプロパティからユーザー情報を取得
+const page = usePage<PageProps>();
+
+/**
+ * ユーザーが管理者かどうかを判定
+ */
+const isAdmin = computed(() => {
+    return page.props.auth.user?.role === 'admin';
+});
+
+/**
+ * ホームルートを取得（ロールに応じて変更）
+ */
+const homeRoute = computed(() => {
+    return isAdmin.value ? route('admin.dashboard') : route('dashboard');
 });
 </script>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -39,6 +39,12 @@ const showingNavigationDropdown = ref(false);
                                 >
                                     Dashboard
                                 </NavLink>
+                                <NavLink
+                                    :href="route('mypage')"
+                                    :active="route().current('mypage')"
+                                >
+                                    マイページ
+                                </NavLink>
                             </div>
                         </div>
 
@@ -71,6 +77,11 @@ const showingNavigationDropdown = ref(false);
                                     </template>
 
                                     <template #content>
+                                        <DropdownLink
+                                            :href="route('mypage')"
+                                        >
+                                            マイページ
+                                        </DropdownLink>
                                         <DropdownLink
                                             :href="route('profile.edit')"
                                         >
@@ -146,6 +157,12 @@ const showingNavigationDropdown = ref(false);
                         >
                             Dashboard
                         </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            :href="route('mypage')"
+                            :active="route().current('mypage')"
+                        >
+                            マイページ
+                        </ResponsiveNavLink>
                     </div>
 
                     <!-- Responsive Settings Options -->
@@ -164,6 +181,9 @@ const showingNavigationDropdown = ref(false);
                         </div>
 
                         <div class="mt-3 space-y-1">
+                            <ResponsiveNavLink :href="route('mypage')">
+                                マイページ
+                            </ResponsiveNavLink>
                             <ResponsiveNavLink :href="route('profile.edit')">
                                 Profile
                             </ResponsiveNavLink>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,30 +1,26 @@
 <script setup>
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import RootLayout from '@/Layouts/RootLayout.vue';
 import { Head } from '@inertiajs/vue3';
 </script>
 
 <template>
-    <Head title="Dashboard" />
+    <Head title="ダッシュボード" />
 
-    <AuthenticatedLayout>
-        <template #header>
-            <h2
-                class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200"
-            >
-                Dashboard
-            </h2>
-        </template>
-
+    <RootLayout>
         <div class="py-12">
             <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <!-- ページヘッダー -->
+                <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
+                    ダッシュボード
+                </h1>
                 <div
                     class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800"
                 >
                     <div class="p-6 text-gray-900 dark:text-gray-100">
-                        You're logged in!
+                        ログインしました！
                     </div>
                 </div>
             </div>
         </div>
-    </AuthenticatedLayout>
+    </RootLayout>
 </template>

--- a/resources/js/Pages/MyPage/Index.test.ts
+++ b/resources/js/Pages/MyPage/Index.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import Index from './Index.vue';
+import type { UserRole, UserStatus } from '@/types/inertia';
+
+// モックコンポーネント
+const mockAuthenticatedLayout = {
+    name: 'AuthenticatedLayout',
+    template: '<div><slot /><slot name="header" /></div>'
+};
+
+const mockHead = {
+    name: 'Head',
+    props: ['title'],
+    template: '<div></div>'
+};
+
+const mockUserStatusBadge = {
+    name: 'UserStatusBadge',
+    props: ['status'],
+    template: '<div>{{ status }}</div>'
+};
+
+describe('MyPage/Index', () => {
+    const mockUser = {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        role: 'user' as UserRole,
+        status: 'active' as UserStatus,
+        created_at: '2025年1月1日',
+        email_verified_at: '2025年1月1日 10:00'
+    };
+
+    const createWrapper = (props = {}) => {
+        return mount(Index, {
+            props: {
+                user: mockUser,
+                ...props
+            },
+            global: {
+                components: {
+                    AuthenticatedLayout: mockAuthenticatedLayout,
+                    Head: mockHead,
+                    UserStatusBadge: mockUserStatusBadge
+                }
+            }
+        });
+    };
+
+    it('ユーザー情報が正しく表示される', () => {
+        const wrapper = createWrapper();
+        
+        expect(wrapper.text()).toContain('マイページ');
+        expect(wrapper.text()).toContain('プロフィール情報');
+        expect(wrapper.text()).toContain(mockUser.name);
+        expect(wrapper.text()).toContain(mockUser.email);
+        expect(wrapper.text()).toContain('一般ユーザー');
+        expect(wrapper.text()).toContain(mockUser.created_at);
+        expect(wrapper.text()).toContain('2025年1月1日 10:00');
+    });
+
+    it('メール未認証の場合、未認証と表示される', () => {
+        const wrapper = createWrapper({
+            user: {
+                ...mockUser,
+                email_verified_at: null
+            }
+        });
+        
+        expect(wrapper.text()).toContain('未認証');
+    });
+
+    it('異なるロールが正しく日本語表示される', () => {
+        const roles: Array<[UserRole, string]> = [
+            ['admin', '管理者'],
+            ['moderator', 'モデレーター'],
+            ['user', '一般ユーザー'],
+            ['guest', 'ゲスト']
+        ];
+
+        roles.forEach(([role, display]) => {
+            const wrapper = createWrapper({
+                user: { ...mockUser, role }
+            });
+            expect(wrapper.text()).toContain(display);
+        });
+    });
+
+    it('アクティビティセクションが表示される', () => {
+        const wrapper = createWrapper();
+        
+        expect(wrapper.text()).toContain('最近のアクティビティ');
+        expect(wrapper.text()).toContain('アクティビティ機能は今後実装予定です。');
+    });
+
+    it('統計情報セクションが表示される', () => {
+        const wrapper = createWrapper();
+        
+        expect(wrapper.text()).toContain('統計情報');
+        expect(wrapper.text()).toContain('ログイン回数');
+        expect(wrapper.text()).toContain('最終ログイン');
+        expect(wrapper.text()).toContain('アカウント使用日数');
+        expect(wrapper.text()).toContain('統計機能は今後実装予定です。');
+    });
+});

--- a/resources/js/Pages/MyPage/Index.vue
+++ b/resources/js/Pages/MyPage/Index.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import UserStatusBadge from '@/Components/Admin/UserStatusBadge.vue';
+import { Head } from '@inertiajs/vue3';
+import type { UserRole, UserStatus } from '@/types/inertia';
+
+/**
+ * マイページのプロパティ定義
+ */
+interface Props {
+    user: {
+        id: number;
+        name: string;
+        email: string;
+        role: UserRole;
+        status: UserStatus;
+        created_at: string;
+        email_verified_at: string | null;
+    };
+}
+
+defineProps<Props>();
+
+/**
+ * ロールの日本語表示を取得
+ * @param role ユーザーロール
+ * @returns 日本語のロール名
+ */
+const getRoleDisplay = (role: UserRole): string => {
+    const roleMap: Record<UserRole, string> = {
+        admin: '管理者',
+        moderator: 'モデレーター',
+        user: '一般ユーザー',
+        guest: 'ゲスト'
+    };
+    return roleMap[role] || role;
+};
+</script>
+
+<template>
+    <Head title="マイページ" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200">
+                マイページ
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <!-- プロフィール情報 -->
+                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                    <div class="p-6">
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                            プロフィール情報
+                        </h3>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <label class="text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    名前
+                                </label>
+                                <p class="mt-1 text-base text-gray-900 dark:text-gray-100">
+                                    {{ user.name }}
+                                </p>
+                            </div>
+                            <div>
+                                <label class="text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    メールアドレス
+                                </label>
+                                <p class="mt-1 text-base text-gray-900 dark:text-gray-100">
+                                    {{ user.email }}
+                                </p>
+                            </div>
+                            <div>
+                                <label class="text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    ロール
+                                </label>
+                                <p class="mt-1 text-base text-gray-900 dark:text-gray-100">
+                                    {{ getRoleDisplay(user.role) }}
+                                </p>
+                            </div>
+                            <div>
+                                <label class="text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    ステータス
+                                </label>
+                                <div class="mt-1">
+                                    <UserStatusBadge :status="user.status" />
+                                </div>
+                            </div>
+                            <div>
+                                <label class="text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    登録日
+                                </label>
+                                <p class="mt-1 text-base text-gray-900 dark:text-gray-100">
+                                    {{ user.created_at }}
+                                </p>
+                            </div>
+                            <div>
+                                <label class="text-sm font-medium text-gray-600 dark:text-gray-400">
+                                    メール認証日時
+                                </label>
+                                <p class="mt-1 text-base text-gray-900 dark:text-gray-100">
+                                    {{ user.email_verified_at || '未認証' }}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- アクティビティ -->
+                <div class="mt-6 overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                    <div class="p-6">
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                            最近のアクティビティ
+                        </h3>
+                        <div class="text-sm text-gray-600 dark:text-gray-400">
+                            <p>アクティビティ機能は今後実装予定です。</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 統計情報 -->
+                <div class="mt-6 overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                    <div class="p-6">
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                            統計情報
+                        </h3>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                                <p class="text-sm text-gray-600 dark:text-gray-400">ログイン回数</p>
+                                <p class="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                                    -
+                                </p>
+                            </div>
+                            <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                                <p class="text-sm text-gray-600 dark:text-gray-400">最終ログイン</p>
+                                <p class="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                                    -
+                                </p>
+                            </div>
+                            <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                                <p class="text-sm text-gray-600 dark:text-gray-400">アカウント使用日数</p>
+                                <p class="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                                    -
+                                </p>
+                            </div>
+                        </div>
+                        <div class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                            <p>統計機能は今後実装予定です。</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/MyPage/Index.vue
+++ b/resources/js/Pages/MyPage/Index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import RootLayout from '@/Layouts/RootLayout.vue';
 import UserStatusBadge from '@/Components/Admin/UserStatusBadge.vue';
 import { Head } from '@inertiajs/vue3';
 import type { UserRole, UserStatus } from '@/types/inertia';
@@ -40,15 +40,13 @@ const getRoleDisplay = (role: UserRole): string => {
 <template>
     <Head title="マイページ" />
 
-    <AuthenticatedLayout>
-        <template #header>
-            <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200">
-                マイページ
-            </h2>
-        </template>
-
+    <RootLayout>
         <div class="py-12">
             <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <!-- ページヘッダー -->
+                <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
+                    マイページ
+                </h1>
                 <!-- プロフィール情報 -->
                 <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
                     <div class="p-6">
@@ -153,5 +151,5 @@ const getRoleDisplay = (role: UserRole): string => {
                 </div>
             </div>
         </div>
-    </AuthenticatedLayout>
+    </RootLayout>
 </template>

--- a/resources/js/Pages/Profile/Edit.vue
+++ b/resources/js/Pages/Profile/Edit.vue
@@ -1,5 +1,5 @@
 <script setup>
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import RootLayout from '@/Layouts/RootLayout.vue';
 import DeleteUserForm from './Partials/DeleteUserForm.vue';
 import UpdatePasswordForm from './Partials/UpdatePasswordForm.vue';
 import UpdateProfileInformationForm from './Partials/UpdateProfileInformationForm.vue';
@@ -16,19 +16,15 @@ defineProps({
 </script>
 
 <template>
-    <Head title="Profile" />
+    <Head title="プロフィール" />
 
-    <AuthenticatedLayout>
-        <template #header>
-            <h2
-                class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200"
-            >
-                Profile
-            </h2>
-        </template>
-
+    <RootLayout>
         <div class="py-12">
             <div class="mx-auto max-w-7xl space-y-6 sm:px-6 lg:px-8">
+                <!-- ページヘッダー -->
+                <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
+                    プロフィール
+                </h1>
                 <div
                     class="bg-white p-4 shadow sm:rounded-lg sm:p-8 dark:bg-gray-800"
                 >
@@ -52,5 +48,5 @@ defineProps({
                 </div>
             </div>
         </div>
-    </AuthenticatedLayout>
+    </RootLayout>
 </template>

--- a/resources/js/types/inertia.d.ts
+++ b/resources/js/types/inertia.d.ts
@@ -1,10 +1,15 @@
 import { DefineComponent } from 'vue'
 
+export type UserRole = 'admin' | 'moderator' | 'user' | 'guest';
+export type UserStatus = 'active' | 'suspended' | 'pending';
+
 export interface User {
   id: number;
   name: string;
   email: string;
   email_verified_at: string | null;
+  role?: UserRole;
+  status?: UserStatus;
 }
 
 export interface PageProps {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\MyPageController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -23,7 +24,7 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     
-    Route::get('/mypage', [\App\Http\Controllers\MyPageController::class, 'index'])->name('mypage');
+    Route::get('/mypage', [MyPageController::class, 'index'])->name('mypage');
 });
 
 Route::get('/components', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    
+    Route::get('/mypage', [\App\Http\Controllers\MyPageController::class, 'index'])->name('mypage');
 });
 
 Route::get('/components', function () {


### PR DESCRIPTION
## 概要
一般ユーザー用のマイページを新規作成しました。

## 変更内容
- `/mypage` ルートを追加
- `MyPageController` を作成し、ユーザー情報を取得
- プロフィール情報、アクティビティ、統計情報のセクションを実装
- ナビゲーションにマイページへのリンクを追加
- マイページコンポーネントのテストを作成

Closes #31

Generated with [Claude Code](https://claude.ai/code)